### PR TITLE
Fix CUDA predictor binding compile errors

### DIFF
--- a/packboost/backends/__init__.py
+++ b/packboost/backends/__init__.py
@@ -10,6 +10,7 @@ cpu_frontier_histogram: Optional[Any]
 cpu_frontier_evaluate: Optional[Any]
 cuda_histogram: Optional[Any]
 cuda_frontier_evaluate: Optional[Any]
+cuda_predict_forest: Optional[Any]
 CudaFrontierWorkspace: Optional[Any]
 
 try:  # pragma: no cover - optional extension
@@ -20,6 +21,7 @@ try:  # pragma: no cover - optional extension
     cpu_frontier_evaluate = getattr(backend, "cpu_frontier_evaluate", None)
     cuda_histogram = getattr(backend, "cuda_histogram", None)
     cuda_frontier_evaluate = getattr(backend, "cuda_frontier_evaluate", None)
+    cuda_predict_forest = getattr(backend, "cuda_predict_forest", None)
     CudaFrontierWorkspace = getattr(backend, "CudaFrontierWorkspace", None)
 except ImportError as exc:  # pragma: no cover - extension not built
     backend_load_error = exc
@@ -28,6 +30,7 @@ except ImportError as exc:  # pragma: no cover - extension not built
     cpu_frontier_evaluate = None
     cuda_histogram = None
     cuda_frontier_evaluate = None
+    cuda_predict_forest = None
     CudaFrontierWorkspace = None
 
 
@@ -47,6 +50,7 @@ __all__ = [
     "cpu_frontier_evaluate",
     "cuda_histogram",
     "cuda_frontier_evaluate",
+    "cuda_predict_forest",
     "CudaFrontierWorkspace",
     "backend_load_error",
     "cpu_available",

--- a/packboost/backends/src/backend_cpu.cpp
+++ b/packboost/backends/src/backend_cpu.cpp
@@ -706,6 +706,18 @@ extern py::tuple cuda_frontier_evaluate_binding(
     int,
     int);
 
+extern py::array_t<float> cuda_predict_forest_binding(
+    py::array_t<uint8_t, py::array::c_style | py::array::forcecast>,
+    py::array_t<int32_t, py::array::c_style | py::array::forcecast>,
+    py::array_t<int32_t, py::array::c_style | py::array::forcecast>,
+    py::array_t<int32_t, py::array::c_style | py::array::forcecast>,
+    py::array_t<int32_t, py::array::c_style | py::array::forcecast>,
+    py::array_t<int32_t, py::array::c_style | py::array::forcecast>,
+    py::array_t<uint8_t, py::array::c_style | py::array::forcecast>,
+    py::array_t<float, py::array::c_style | py::array::forcecast>,
+    double,
+    double);
+
 extern void bind_cuda_workspace(py::module_&);
 #endif
 
@@ -755,6 +767,21 @@ PYBIND11_MODULE(_backend, m) {
         py::arg("era_tile_size"),
         py::arg("threads_per_block"),
         py::arg("rows_per_thread"));
+
+    m.def(
+        "cuda_predict_forest",
+        &cuda_predict_forest_binding,
+        "Predict using a flattened forest on the GPU",
+        py::arg("bins"),
+        py::arg("tree_offsets"),
+        py::arg("features"),
+        py::arg("thresholds"),
+        py::arg("lefts"),
+        py::arg("rights"),
+        py::arg("is_leaf"),
+        py::arg("values"),
+        py::arg("tree_weight"),
+        py::arg("initial_prediction"));
 
     bind_cuda_workspace(m);
 #endif

--- a/tests/test_model_flatten.py
+++ b/tests/test_model_flatten.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from packboost.config import PackBoostConfig
+from packboost.model import PackBoostModel, Tree, TreeNode
+
+
+def test_flatten_forest_structure() -> None:
+    config = PackBoostConfig()
+    tree = Tree()
+    root_id = tree.add_node(
+        TreeNode(
+            is_leaf=False,
+            prediction=0.5,
+            feature=1,
+            threshold=2,
+            left=1,
+            right=2,
+            depth=0,
+        )
+    )
+    assert root_id == 0
+    tree.add_node(TreeNode(is_leaf=True, prediction=1.5, depth=1))
+    tree.add_node(TreeNode(is_leaf=True, prediction=-0.5, depth=1))
+
+    model = PackBoostModel(
+        config=config,
+        bin_edges=None,
+        initial_prediction=0.1,
+        trees=[tree],
+    )
+
+    flattened = model.flatten_forest()
+
+    np.testing.assert_array_equal(flattened.tree_offsets, np.array([0, 3], dtype=np.int32))
+    np.testing.assert_array_equal(flattened.features, np.array([1, -1, -1], dtype=np.int32))
+    np.testing.assert_array_equal(flattened.thresholds, np.array([2, -1, -1], dtype=np.int32))
+    np.testing.assert_array_equal(flattened.lefts, np.array([1, -1, -1], dtype=np.int32))
+    np.testing.assert_array_equal(flattened.rights, np.array([2, -1, -1], dtype=np.int32))
+    np.testing.assert_array_equal(flattened.is_leaf, np.array([0, 1, 1], dtype=np.uint8))
+    np.testing.assert_array_equal(flattened.values, np.array([0.5, 1.5, -0.5], dtype=np.float32))
+
+    # Cached result should be reused
+    assert model.flatten_forest() is flattened


### PR DESCRIPTION
## Summary
- add a translation-unit CUDA error helper that both the workspace code and Python bindings can reuse
- move the `predict_forest_kernel` definition outside the anonymous namespace and update the binding launch to reference it directly

## Testing
- `python -m pip install -e .`
- `pytest tests/test_model_flatten.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd616fa70083208964b46ed1f7298b